### PR TITLE
support custom embeds in inference

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -15,13 +15,19 @@ def main():
     llm = LLM(path, enforce_eager=False, max_model_len=4096)
 
     prompt_token_ids = [[randint(0, 10000) for _ in range(randint(100, max_input_len))] for _ in range(num_seqs)]
+    requests = []
+    for tokens in prompt_token_ids:
+        embeds = llm.model_runner.call("get_input_embeddings", tokens)
+        pos_ids = list(range(len(tokens)))
+        hashes = list(tokens)
+        requests.append(dict(prompt_token_ids=tokens, prompt_embeds=embeds, position_ids=pos_ids, token_hashes=hashes))
     sampling_params = [SamplingParams(temperature=0.6, ignore_eos=True, max_tokens=randint(100, max_ouput_len)) for _ in range(num_seqs)]
     # uncomment the following line for vllm
     # prompt_token_ids = [dict(prompt_token_ids=p) for p in prompt_token_ids]
 
     llm.generate(["Benchmark: "], SamplingParams())
     t = time.time()
-    llm.generate(prompt_token_ids, sampling_params, use_tqdm=False)
+    llm.generate(requests, sampling_params, use_tqdm=False)
     t = (time.time() - t)
     total_tokens = sum(sp.max_tokens for sp in sampling_params)
     throughput = total_tokens / t

--- a/example.py
+++ b/example.py
@@ -22,7 +22,14 @@ def main():
         )
         for prompt in prompts
     ]
-    outputs = llm.generate(prompts, sampling_params)
+    requests = []
+    for prompt in prompts:
+        token_ids = tokenizer.encode(prompt)
+        embeds = llm.model_runner.call("get_input_embeddings", token_ids)
+        pos_ids = list(range(len(token_ids)))
+        hashes = list(token_ids)
+        requests.append(dict(prompt_token_ids=token_ids, prompt_embeds=embeds, position_ids=pos_ids, token_hashes=hashes))
+    outputs = llm.generate(requests, sampling_params)
 
     for prompt, output in zip(prompts, outputs):
         print("\n")

--- a/nanovllm/engine/block_manager.py
+++ b/nanovllm/engine/block_manager.py
@@ -63,7 +63,15 @@ class BlockManager:
         cache_miss = False
         for i in range(seq.num_blocks):
             token_ids = seq.block(i)
-            h = self.compute_hash(token_ids, h) if len(token_ids) == self.block_size else -1
+            if len(token_ids) == self.block_size:
+                start = i * self.block_size
+                end = start + self.block_size
+                if len(seq.token_hashes) >= end:
+                    h = self.compute_hash(seq.token_hashes[start:end], h)
+                else:
+                    h = self.compute_hash(token_ids, h)
+            else:
+                h = -1
             block_id = self.hash_to_block_id.get(h, -1)
             if block_id == -1 or self.blocks[block_id].token_ids != token_ids:
                 cache_miss = True
@@ -106,7 +114,12 @@ class BlockManager:
             assert last_block.hash == -1
             token_ids = seq.block(seq.num_blocks-1)
             prefix = self.blocks[block_table[-2]].hash if len(block_table) > 1 else -1
-            h = self.compute_hash(token_ids, prefix)
+            start = (seq.num_blocks - 1) * self.block_size
+            end = start + self.block_size
+            if len(seq.token_hashes) >= end:
+                h = self.compute_hash(seq.token_hashes[start:end], prefix)
+            else:
+                h = self.compute_hash(token_ids, prefix)
             last_block.update(h, token_ids)
             self.hash_to_block_id[h] = last_block.block_id
         else:

--- a/nanovllm/engine/llm_engine.py
+++ b/nanovllm/engine/llm_engine.py
@@ -39,10 +39,21 @@ class LLMEngine:
         for p in self.ps:
             p.join()
 
-    def add_request(self, prompt: str | list[int], sampling_params: SamplingParams):
-        if isinstance(prompt, str):
-            prompt = self.tokenizer.encode(prompt)
-        seq = Sequence(prompt, sampling_params)
+    def add_request(self, prompt, sampling_params: SamplingParams):
+        if isinstance(prompt, dict):
+            token_ids = prompt["prompt_token_ids"]
+            input_embeds = prompt["prompt_embeds"]
+            position_ids = prompt["position_ids"]
+            token_hashes = prompt.get("token_hashes", [])
+        else:
+            if isinstance(prompt, str):
+                token_ids = self.tokenizer.encode(prompt)
+            else:
+                token_ids = prompt
+            input_embeds = None
+            position_ids = None
+            token_hashes = None
+        seq = Sequence(token_ids, sampling_params, input_embeds, position_ids, token_hashes)
         self.scheduler.add(seq)
 
     def step(self):

--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -1,4 +1,5 @@
 import pickle
+from functools import cached_property
 import torch
 import torch.distributed as dist
 from multiprocessing.synchronize import Event
@@ -47,6 +48,10 @@ class ModelRunner:
                 self.shm = SharedMemory(name="nanovllm")
                 self.loop()
 
+    @cached_property
+    def uses_mrope(self):
+        return getattr(self.model, "uses_mrope", False)
+
     def exit(self):
         if self.world_size > 1:
             self.shm.close()
@@ -93,7 +98,14 @@ class ModelRunner:
         torch.cuda.reset_peak_memory_stats()
         max_num_batched_tokens, max_model_len = self.config.max_num_batched_tokens, self.config.max_model_len
         num_seqs = min(max_num_batched_tokens // max_model_len, self.config.max_num_seqs)
-        seqs = [Sequence([0] * max_model_len) for _ in range(num_seqs)]
+        dummy_ids = [0] * max_model_len
+        sample_embed = self.model.get_input_embeddings(torch.tensor([0]))[0]
+        dummy_embeds = [torch.zeros_like(sample_embed) for _ in range(max_model_len)]
+        if self.uses_mrope:
+            positions = torch.arange(max_model_len, dtype=torch.int64).unsqueeze(0).expand(3, -1)
+        else:
+            positions = torch.arange(max_model_len, dtype=torch.int64)
+        seqs = [Sequence(dummy_ids, input_embeds=dummy_embeds, position_ids=positions) for _ in range(num_seqs)]
         self.run(seqs, True)
         torch.cuda.empty_cache()
 
@@ -123,7 +135,7 @@ class ModelRunner:
         return block_tables
 
     def prepare_prefill(self, seqs: list[Sequence]):
-        input_ids = []
+        input_embeds = []
         positions = []
         cu_seqlens_q = [0]
         cu_seqlens_k = [0]
@@ -133,8 +145,17 @@ class ModelRunner:
         block_tables = None
         for seq in seqs:
             seqlen = len(seq)
-            input_ids.extend(seq[seq.num_cached_tokens:])
-            positions.extend(list(range(seq.num_cached_tokens, seqlen)))
+            if seq.input_embeds is None:
+                embeds = self.get_input_embeddings(seq.token_ids)
+                embeds = embeds[seq.num_cached_tokens:]
+            else:
+                assert len(seq.input_embeds) == len(seq.token_ids)
+                embeds = torch.stack(seq.input_embeds[seq.num_cached_tokens:])
+            input_embeds.append(embeds)
+            if self.uses_mrope:
+                positions.append(seq.position_ids[:, seq.num_cached_tokens:])
+            else:
+                positions.append(seq.position_ids[seq.num_cached_tokens:])
             seqlen_q = seqlen - seq.num_cached_tokens
             seqlen_k = seqlen
             cu_seqlens_q.append(cu_seqlens_q[-1] + seqlen_q)
@@ -152,13 +173,16 @@ class ModelRunner:
                 slot_mapping.extend(list(range(start, end)))
         if cu_seqlens_k[-1] > cu_seqlens_q[-1]:    # prefix cache
             block_tables = self.prepare_block_tables(seqs)
-        input_ids = torch.tensor(input_ids, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
-        positions = torch.tensor(positions, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
+        input_embeds = torch.cat([torch.stack(e) if isinstance(e, list) else e for e in input_embeds], dim=0).cuda(non_blocking=True)
+        if self.uses_mrope:
+            positions = torch.cat([p if torch.is_tensor(p) else torch.tensor(p) for p in positions], dim=1).cuda(non_blocking=True)
+        else:
+            positions = torch.cat([p if torch.is_tensor(p) else torch.tensor(p) for p in positions]).cuda(non_blocking=True)
         cu_seqlens_q = torch.tensor(cu_seqlens_q, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         cu_seqlens_k = torch.tensor(cu_seqlens_k, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         slot_mapping = torch.tensor(slot_mapping, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         set_context(True, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping, None, block_tables)
-        return input_ids, positions
+        return input_embeds, positions
 
     def prepare_decode(self, seqs: list[Sequence]):
         input_ids = []
@@ -167,16 +191,20 @@ class ModelRunner:
         context_lens = []
         for seq in seqs:
             input_ids.append(seq.last_token)
-            positions.append(len(seq))
+            positions.append(self.model.get_next_position_id(seq.position_ids, len(seq)))
             context_lens.append(len(seq))
             slot_mapping.append(seq.block_table[-1] * self.block_size + seq.last_block_num_tokens  - 1)
         input_ids = torch.tensor(input_ids, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
-        positions = torch.tensor(positions, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
+        input_embeds = self.model.get_input_embeddings(input_ids)
+        if self.uses_mrope:
+            positions = torch.stack(positions, dim=1).cuda(non_blocking=True)
+        else:
+            positions = torch.tensor(positions, dtype=torch.int64, pin_memory=True).cuda(non_blocking=True)
         slot_mapping = torch.tensor(slot_mapping, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         context_lens = torch.tensor(context_lens, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         block_tables = self.prepare_block_tables(seqs)
         set_context(False, slot_mapping=slot_mapping, context_lens=context_lens, block_tables=block_tables)
-        return input_ids, positions
+        return input_embeds, positions
 
     def prepare_sample(self, seqs: list[Sequence]):
         temperatures = []
@@ -186,31 +214,39 @@ class ModelRunner:
         return temperatures
 
     @torch.inference_mode()
-    def run_model(self, input_ids: torch.Tensor, positions: torch.Tensor, is_prefill: bool):
-        if is_prefill or self.enforce_eager or input_ids.size(0) > 512:
-            return self.model.compute_logits(self.model(input_ids, positions))
+    def run_model(self, input_embeds: torch.Tensor, positions: torch.Tensor, is_prefill: bool):
+        if is_prefill or self.enforce_eager or input_embeds.size(0) > 512:
+            return self.model.compute_logits(self.model(input_embeds, positions))
         else:
-            bs = input_ids.size(0)
+            bs = input_embeds.size(0)
             context = get_context()
             graph = self.graphs[next(x for x in self.graph_bs if x >= bs)]
             graph_vars = self.graph_vars
             for k, v in graph_vars.items():
                 if k != "outputs":
                     v.zero_()
-            graph_vars["input_ids"][:bs] = input_ids
-            graph_vars["positions"][:bs] = positions
+            graph_vars["input_embeds"][:bs] = input_embeds
+            if self.uses_mrope:
+                graph_vars["positions"][:, :bs] = positions
+            else:
+                graph_vars["positions"][:bs] = positions
             graph_vars["slot_mapping"][:bs] = context.slot_mapping
             graph_vars["context_lens"][:bs] = context.context_lens
             graph_vars["block_tables"][:bs, :context.block_tables.size(1)] = context.block_tables
             graph.replay()
             return self.model.compute_logits(graph_vars["outputs"][:bs])
 
-    def run(self, seqs: list[Sequence], is_prefill: bool) -> list[int]:
-        input_ids, positions = self.prepare_prefill(seqs) if is_prefill else self.prepare_decode(seqs)
+    def run(self, seqs: list[Sequence], is_prefill: bool):
+        input_embeds, positions = (
+            self.prepare_prefill(seqs) if is_prefill else self.prepare_decode(seqs)
+        )
         temperatures = self.prepare_sample(seqs) if self.rank == 0 else None
-        logits = self.run_model(input_ids, positions, is_prefill)
-        token_ids = self.sampler(logits, temperatures).tolist() if self.rank == 0 else None
+        logits = self.run_model(input_embeds, positions, is_prefill)
+        token_ids = (
+            self.sampler(logits, temperatures).tolist() if self.rank == 0 else None
+        )
         reset_context()
+        # seq.input_embeds and seq.position_ids are unused during decode
         return token_ids
 
     @torch.inference_mode()
@@ -219,8 +255,9 @@ class ModelRunner:
         hf_config = config.hf_config
         max_bs = min(self.config.max_num_seqs, 512)
         max_num_blocks = (config.max_model_len + self.block_size - 1) // self.block_size
-        input_ids = torch.zeros(max_bs, dtype=torch.int64)
-        positions = torch.zeros(max_bs, dtype=torch.int64)
+        input_embeds = torch.zeros(max_bs, hf_config.hidden_size)
+        pos_shape = (3, max_bs) if self.uses_mrope else (max_bs,)
+        positions = torch.zeros(pos_shape, dtype=torch.int64)
         slot_mapping = torch.zeros(max_bs, dtype=torch.int32)
         context_lens = torch.zeros(max_bs, dtype=torch.int32)
         block_tables = torch.zeros(max_bs, max_num_blocks, dtype=torch.int32)
@@ -232,9 +269,10 @@ class ModelRunner:
         for bs in reversed(self.graph_bs):
             graph = torch.cuda.CUDAGraph()
             set_context(False, slot_mapping=slot_mapping[:bs], context_lens=context_lens[:bs], block_tables=block_tables[:bs])
-            outputs[:bs] = self.model(input_ids[:bs], positions[:bs])    # warmup
+            pos_view = positions[:, :bs] if self.uses_mrope else positions[:bs]
+            outputs[:bs] = self.model(input_embeds[:bs], pos_view)    # warmup
             with torch.cuda.graph(graph, self.graph_pool):
-                outputs[:bs] = self.model(input_ids[:bs], positions[:bs])    # capture
+                outputs[:bs] = self.model(input_embeds[:bs], pos_view)    # capture
             if self.graph_pool is None:
                 self.graph_pool = graph.pool()
             self.graphs[bs] = graph
@@ -242,10 +280,23 @@ class ModelRunner:
             reset_context()
 
         self.graph_vars = dict(
-            input_ids=input_ids,
+            input_embeds=input_embeds,
             positions=positions,
             slot_mapping=slot_mapping,
             context_lens=context_lens,
             block_tables=block_tables,
             outputs=outputs,
         )
+
+    def get_input_embeddings(self, input_ids):
+        if not torch.is_tensor(input_ids):
+            input_ids = torch.tensor(input_ids, dtype=torch.int64)
+        input_ids = input_ids.cuda()
+        embeds = self.model.get_input_embeddings(input_ids).cpu()
+        return embeds
+
+    def get_next_position_id(self, position_ids_list, lengths):
+        results = []
+        for pos, l in zip(position_ids_list, lengths):
+            results.append(self.model.get_next_position_id(pos, l))
+        return results

--- a/nanovllm/engine/sequence.py
+++ b/nanovllm/engine/sequence.py
@@ -1,6 +1,7 @@
 from copy import copy
 from enum import Enum, auto
 from itertools import count
+import torch
 
 from nanovllm.sampling_params import SamplingParams
 
@@ -15,7 +16,14 @@ class Sequence:
     block_size = 256
     counter = count()
 
-    def __init__(self, token_ids: list[int], sampling_params = SamplingParams()):
+    def __init__(
+        self,
+        token_ids: list[int],
+        sampling_params: SamplingParams = SamplingParams(),
+        input_embeds=None,
+        position_ids=None,
+        token_hashes: list[int] | None = None,
+    ):
         self.seq_id = next(Sequence.counter)
         self.status = SequenceStatus.WAITING
         self.token_ids = copy(token_ids)
@@ -27,6 +35,14 @@ class Sequence:
         self.temperature = sampling_params.temperature
         self.max_tokens = sampling_params.max_tokens
         self.ignore_eos = sampling_params.ignore_eos
+        self.input_embeds = None if input_embeds is None else [e.cpu() for e in input_embeds]
+        if position_ids is None:
+            self.position_ids = torch.arange(len(token_ids), dtype=torch.int64)
+        else:
+            if not torch.is_tensor(position_ids):
+                position_ids = torch.tensor(position_ids, dtype=torch.int64)
+            self.position_ids = position_ids.cpu()
+        self.token_hashes = [] if token_hashes is None else list(token_hashes)
 
     def __len__(self):
         return self.num_tokens
@@ -72,12 +88,35 @@ class Sequence:
         self.num_tokens += 1
 
     def __getstate__(self):
-        return (self.num_tokens, self.num_prompt_tokens, self.num_cached_tokens, self.block_table,
-                self.token_ids if self.num_completion_tokens == 0 else self.last_token)
+        return (
+            self.num_tokens,
+            self.num_prompt_tokens,
+            self.num_cached_tokens,
+            self.block_table,
+            self.token_ids if self.num_completion_tokens == 0 else self.last_token,
+            self.input_embeds if self.num_completion_tokens == 0 else None,
+            self.position_ids,
+            self.token_hashes,
+        )
 
     def __setstate__(self, state):
-        self.num_tokens, self.num_prompt_tokens, self.num_cached_tokens, self.block_table = state[:-1]
+        (
+            self.num_tokens,
+            self.num_prompt_tokens,
+            self.num_cached_tokens,
+            self.block_table,
+            token_ids_or_last,
+            input_embeds,
+            position_ids,
+            self.token_hashes,
+        ) = state
         if self.num_completion_tokens == 0:
-            self.token_ids = state[-1]
+            self.token_ids = token_ids_or_last
+            self.input_embeds = input_embeds
+            self.last_token = self.token_ids[-1]
         else:
-            self.last_token = state[-1]
+            self.last_token = token_ids_or_last
+            self.input_embeds = []
+        if not torch.is_tensor(position_ids):
+            position_ids = torch.tensor(position_ids, dtype=torch.int64)
+        self.position_ids = position_ids.cpu()

--- a/nanovllm/models/qwen3.py
+++ b/nanovllm/models/qwen3.py
@@ -170,10 +170,10 @@ class Qwen3Model(nn.Module):
 
     def forward(
         self,
-        input_ids: torch.Tensor,
+        inputs_embeds: torch.Tensor,
         positions: torch.Tensor,
     ) -> torch.Tensor:
-        hidden_states = self.embed_tokens(input_ids)
+        hidden_states = inputs_embeds
         residual = None
         for layer in self.layers:
             hidden_states, residual = layer(positions, hidden_states, residual)
@@ -199,13 +199,27 @@ class Qwen3ForCausalLM(nn.Module):
         self.lm_head = ParallelLMHead(config.vocab_size, config.hidden_size)
         if config.tie_word_embeddings:
             self.lm_head.weight.data = self.model.embed_tokens.weight.data
+        self.uses_mrope = False
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_tokens(input_ids)
+
+    def get_next_position_id(self, position_ids, length: int):
+        if self.uses_mrope:
+            if torch.is_tensor(position_ids):
+                return position_ids[:, 0] + length
+            return [row[0] + length for row in position_ids]
+        else:
+            if torch.is_tensor(position_ids):
+                return position_ids[0] + length
+            return position_ids[0] + length
 
     def forward(
         self,
-        input_ids: torch.Tensor,
+        inputs_embeds: torch.Tensor,
         positions: torch.Tensor,
     ) -> torch.Tensor:
-        hidden_states = self.model(input_ids, positions)
+        hidden_states = self.model(inputs_embeds, positions)
         return hidden_states
 
     def compute_logits(


### PR DESCRIPTION
## Summary
- generate token hashes per token and use them in cache logic
- skip position tracking when appending tokens
- compute next position ID based on the start offset
- adjust examples to supply per-token hashes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6869784bdad483319de59ffae8d5ab0b